### PR TITLE
Don't increment the count on skipped lines (white space, etc)

### DIFF
--- a/plugin/visual-increment.vim
+++ b/plugin/visual-increment.vim
@@ -39,9 +39,11 @@ function! s:doincrement(step, ...)
       if line('.') == end_row
         break
       endif
+      if start_column < col("$")
+        let i += a:step
+      endif
       " move to the next line
       call setpos('.', [0, line('.')+1, start_column, 0])
-      let i += a:step
     endwhile
   endif
 endfunction


### PR DESCRIPTION
For example, Select and C-a:

```
0
0

0
```

Now will give:

```
0
1

2
```

Instead of:

```
0
1

3
```
